### PR TITLE
Summer 2017 OAQ updates

### DIFF
--- a/articles/account_management.md
+++ b/articles/account_management.md
@@ -6,11 +6,11 @@
 
 OAQ is designed to be a multi-tenant platform, which means multiple publishers can use it simultaneously with their own users and branding. This means your organization's data will remain invisible to other publishers.
 
-Note that when we say "publisher" in this documentation, we mean an organization with an [organization type](organizations) of _publisher_. The other organization type available is _library_.
+Note that when we say "publisher" in this documentation, we mean an organization with an [organization type](organizations) of **publisher**. The other organization type available is [**library**](https://oaq-docs.github.io/library-workflow).
 
 ## Types of account roles
 
-The OAQ application supports several types of **account roles**, each with different views and access. Here they are in order from most to least permissions:
+The OAQ application supports several types of **account roles**, each with different views and permissions. Here they are in order from most to least access:
 
 | Account role | Permissions |
 |--|--|
@@ -26,6 +26,10 @@ Before anyone from your organization can do anything in OAQ, a site admin will n
 Your experience as a publisher in OAQ begins when the site admin invites the first member (or members) to the organization to be an  **organization admin**.
 
 Each invited organization admin will receive an email that contains an invitation link. If you receive one of these emails and click the link, you will be taken to a page in OAQ where you can confirm your account and create a password. Note that you can always [change your password](account_management#changing-your-password) later.
+
+## Associating your organization with libraries
+
+OAQ facilitates the sharing of questionnaire data between publishers and libraries. As a publisher, you can [share author responses](questionnaires#accepting-a-response) with any library of your choosing. Only OAQ [site admins](#types-of-account-roles) can set up publisher–library associations, so talk to the site admin who creates your organization about the libraries you wish to work with.
 
 ## Inviting others to the organization
 

--- a/articles/organizations.md
+++ b/articles/organizations.md
@@ -6,7 +6,7 @@
 
 An organization in OAQ may be one of two types: publisher or library. This documentation is intended for a publisher workflow.
 
-An organization must have at least one **organization admin** who may create additional **organization staff**. These staff can create and manage questionnaires, invite authors to respond to them, and manage author responses.
+An organization must have at least one **organization admin** who may create additional **organization staff**. These staff members can [create and manage questionnaires](questionnaires#creating-a-new-questionnaire), [invite authors to respond to them](questionnaires#sending-a-questionnaire-to-an-author), and [manage author responses](questionnaires#managing-responses).
 
 ## Editing organization details
 
@@ -17,7 +17,16 @@ If you are an organization admin, you can customize details about your organizat
 3. To upload a logo, click **Choose File** and select an image file in PNG or JPG format. This image will appear next to the OAQ logo at the top of the screen and in all your organization's questionnaires.
 4. Fill in as many of the rest of the fields as you'd like.
 5. To participate in the [ECIP](https://www.loc.gov/publish/cip/about/) program, select the checkbox.
-6. Click **Update** to save your details, or click **Cancel** to discard the changes and go back.
+6. Click **Update** to save the details, or click **Cancel** to discard your changes.
+
+## Customizing your organization's questionnaire invitation email
+
+If you are an organization admin, you can customize the email message that will be sent to authors when you [invite them](#questionnaires#sending-a-questionnaire-to-an-author) to questionnaires.
+
+1. Click **Organization** in the top bar.
+2. Click **Edit Email Message**.
+3. Edit the email text as desired. Note that any words in curly braces are values that will be generated dynamically at the time each email is sent. For example, an author's real email address will be substituted programmatically into the phrase "Hello, {{author_email}}" (without the braces).
+4. Click **Update** to save the message, or click **Cancel** to discard your changes.
 
 ## Managing organization users
 

--- a/articles/questionnaires.md
+++ b/articles/questionnaires.md
@@ -11,16 +11,16 @@ In OAQ, the core objects of a questionnaire are [sections](#creating-a-new-secti
 ## Creating a new questionnaire
 
 1. Click **Questionnaires** in the top bar to view a list of all your organization's questionnaires.
-2. Click **Create new questionnaire**. Alternatively, click **+ Add a questionnaire** in the top bar.
-3. In the popup window, enter a name and description for the questionnaire. This text will be only visible to users within your organization, not authors. You can also edit these details later.
-4. Click **Create** to save the new questionnaire, or click **Close** to discard your changes and go back.
+2. Click **Create a new questionnaire**. Alternatively, click **+ Add a questionnaire** in the top bar.
+3. In the popup window, enter a name and description for the questionnaire. This text will be visible only to users within your organization, not authors. You can also edit these details later.
+4. Click **Create** to save the new questionnaire, or click **Close** to discard your changes.
 
 If you click **Create**, you will be taken to the [Edit Questionnaire](#editing-a-questionnaire) page. The questionnaire will be saved to your organization's list, so you can get back to it at any time by clicking **Questionnaires** in the top bar.
 
 ### Essential Questions section
 {:.no_toc}
 
-OAQ requires the collection of some basic author information. This means that when you create a new questionnaire, it will contain a default section called **Essential questions**. You cannot delete these questions, but you can rename it or distribute the questions to other sections. You can also move questions from other sections into the Essential Questions, but you cannot currently create a new question directly in this section.
+OAQ requires the collection of some basic author information. This means that when you create a new questionnaire, it will contain a default section called **Essential questions**. You cannot delete these questions, but you can rename the section or distribute the questions to other sections. You can also move questions from other sections into the Essential Questions section, but you cannot create a new question directly in this section.
 
 ## Actions you can perform on a questionnaire
 
@@ -30,7 +30,7 @@ OAQ allows you to perform a number of actions on a saved questionnaire. When you
 |--|--|
 |View|Shows a [view](#viewing-a-questionnaire) of the questionnaire as the author will see it.|
 |Edit|Takes you to the [Edit Questionnaire](#editing-a-questionnaire) page.|
-|Send to author|Pops up a window where you can [invite authors](#sending-a-questionnaire-to-an-author) to the questionnaire.|
+|Send to authors|Pops up a window where you can [invite authors](#sending-a-questionnaire-to-an-author) to the questionnaire.|
 |Clone|Pops up a window where you can enter a name and description in order to [clone](#cloning-a-questionnaire) the questionnaire.|
 |Responses|Takes you to a page where you can [manage author responses](#managing-responses) for the questionnaire.|
 
@@ -59,9 +59,9 @@ The following sections provide more detail on editing functions.
 ### Creating a new section
 {:.no_toc}
 
-1. On the **Edit Questionnaire** page, click **Add New Section**.
-2. In the popup window, add a name and description for the section. For example, if you want to group questions related to biography together, you might enter the name "Biographical information" and add some descriptive text. (Note you can edit the name and description at any time from the main **Edit Questionnaire** page.)
-3. Click **Create** to save the section, or click **Close** to discard your changes and go back.
+1. On the Edit Questionnaire page, click **Add New Section**.
+2. In the popup window, add a name and description for the section. For example, if you want to group questions related to biographical details together, you might enter the name "Biographical information" and add some descriptive text. (Note you can edit the name and description at any time from the main Edit Questionnaire page.)
+3. Click **Create** to save the section, or click **Close** to discard your changes.
 
 Clicking **Create** will take you back to the Edit Questionnaire page where your new section will appear at the bottom of the page.
 
@@ -70,26 +70,26 @@ Clicking **Create** will take you back to the Edit Questionnaire page where your
 
 Once you have created a new section in your questionnaire, you can manage questions within it.
 
-1. On the **Edit Questionnaire** page, find the section you want to manage.
+1. On the Edit Questionnaire page, find the section you want to manage.
 2. Click **Add / Remove questions**.
 
 This will take you to a page where you can perform the following actions.
 
-#### Create a brand new question and add it to the section
+#### Create a new question and add it to the section
 {:.no_toc}
 
 1. Click **Create new question**.
 2. In the popup window, fill out the [question components](questions#question-components).
-3. Click **Create** to save the question, or click **Cancel** to discard your changes and go back.
+3. Click **Create** to save the question, or click **Cancel** to discard your changes.
 
-Note that if you create a new question this way, it will appear within the section and will _also_ be added to the [organization-wide questions](questions). You can also do the latter process [separately](questions#creating-a-new-question).
+Note that if you create a new question this way, it will appear within the section and will _also_ be added to the [organization-wide questions](questions). Alternatively, you can [create an organization-wide question](questions#creating-a-new-question) directly.
 
 #### Add an existing question to the section
 {:.no_toc}
 
-This step requires that you have previously added at least one [organization-wide question](questions).
+This step requires you to have previously added at least one [organization-wide question](questions).
 
-1. Under **Add Questions**, select a question from the dropdown (or start typing its name in the search box). Note that all organization-wide questions will appear as options in the dropdown except for [essential questions](#essential-questions-section) and questions already in the questionnaire.
+1. Under **Add Questions**, select a question from the dropdown (or start typing its name in the search box). Note that all organization-wide questions will appear as options in the dropdown, but any questions already in the questionnaire will be dimmed; questions that are available to be added will be shown at the top of the results list.
 2. Click **Add Question**.
 3. Confirm that the question appears under **Questions Currently In this Section**.
 
@@ -100,14 +100,14 @@ This step requires that you have previously added at least one [organization-wid
 2. In the popup window, click **Yes** to remove the question, or click **No** to go back.
 3. Confirm that the question has disappeared from **Questions Currently In this Section** and is once again available in the dropdown.
 
-Note that this process will only remove the question from the _questionnaire_. The question will still exist in the [organization-wide questions](questions).
+Note that this process will only remove the question from the individual _questionnaire_. The question will still exist in the [organization-wide questions](questions).
 
 When you have finished with this page, click **Done Adding Questions, Take Me Back To Section Editor**.
 
 ### Moving elements around
 {:.no_toc}
 
-The Edit Questionnaire page provides a drag-and-drop interface so you can easily reorder questions and sections within a questionnaire.
+The **Edit Questionnaire** page provides a drag-and-drop interface so you can easily reorder questions and sections within a questionnaire.
 
 #### Moving a question within a section
 {:.no_toc}
@@ -119,7 +119,7 @@ The Edit Questionnaire page provides a drag-and-drop interface so you can easily
 #### Moving a question to another section
 
 1. To the right of the question, click the link that says **Move to another section**.
-2. In the popup window, select the section from the dropdown under **To** that you want to move the question to.
+2. In the popup window, select the section from the dropdown under **To** that you want to move the question into.
 3. Click **Move**.
 4. Confirm that the question has moved to the desired section.
 
@@ -137,15 +137,17 @@ The Edit Questionnaire page provides a drag-and-drop interface so you can easily
 
 ## Sending a questionnaire to an author
 
-Once you are satisfied with your questionnaire, click **I Am Done Making My Questionnaire** at the bottom of the Edit Questionnaire  page. You can now begin sharing it with authors.
+When you are satisfied with your questionnaire, click **I Am Done Making My Questionnaire** at the bottom of the Edit Questionnaire page. You can now begin sharing it with authors.
 
 1. Click **Questionnaires** in the top bar to view a list of all your organization's questionnaires.
 2. Find the name of the questionnaire you want to share.
-3. Under **Actions**, click **Send to author**. (Alternatively, you can click either **View** or **Responses**, then click **Invite Author To Answer The Questionnaire**.)
-4. In the popup window, enter the author's email address. If you're sending to multiple authors at once, make sure to press _Enter_ after typing each address before typing the next one.
-5. Click **Invite** to send the email, or click **Close** to discard your changes and go back.
+3. Under **Actions**, click **Send to authors**. (Alternatively, you can click either **View** or **Responses**, then click **Invite authors to answer the questionnaire**.)
+4. In the popup window, enter the author's email address. If you're sending to multiple authors at once, press _Enter_ after typing each address before typing the next one.
+5. Click **Invite** to send the email, or click **Close** to discard your changes.
 
-Clicking **Invite** will send the recipients an email with a link to your questionnaire. Additionally, the questionnaire will be added to the [Responses list](#managing-responses) with a status of _Sent_.
+Clicking **Invite** will send the recipients your [organization's customized email message](organizations#customizing-your-organization-s-questionnaire-invitation-email) with a link to your questionnaire. Additionally, the questionnaire will be added to the [Responses list](#managing-responses) with a [status](#response-status) of _Sent_.
+
+The publisher staff member who sends the invite will get an email notification when an author has submitted a response.
 
 ## Cloning a questionnaire
 
@@ -161,48 +163,68 @@ Clicking **Clone** will save the new questionnaire to your organization's list. 
 
 ## Managing responses
 
-After you've sent a questionnaire to an author, you can view and manage the status of their responses.
+After you've sent a questionnaire to authors, you can view and manage the status of their responses.
 
 1. Click **Questionnaires** in the top bar to view a list of all your organization's questionnaires.
 2. Find the name of the questionnaire that has the author responses you want to manage.
 3. Under **Actions**, click **Responses**.
 
-The **Answers for questionnaire** page will show a list of each author who has been invited to the questionnaire, along with the date it was last modified and the [status](#response-status) of the response.
+The **Responses for questionnaire** page will show a list of each author who has been invited to the questionnaire, along with the date it was last modified and the [status](#response-status) of the response.
 
-As a publisher, there may be times where you want to work on a questionnaire on behalf of an author. If you click **Submit a new response** at the top of the page, you can begin a questionnaire without generating an email to an author. You can then either submit it yourself or share the URL with the author later. You can also work on an author's in-progress questionnaire by clicking **Edit** next to its name in the list.
+As a publisher, there may be times where you want to work on a questionnaire on behalf of an author. If you click **Start a new response to <name of questionnaire>** at the top of the page, you can begin a questionnaire without generating an email to an author. You can then either submit the questionnaire yourself or share the URL with the author later. You can also work on an author's in-progress questionnaire by clicking **Edit** next to its name in the list.
 
 ### Response status
 {:.no_toc}
 
-Here's an explanation of the **Status** dropdown menu options:
+Here’s an explanation of the **Status** dropdown menu options:
 
-| Status | Explanation |
+| Status | Meaning |
 |--|--|
 |Sent|The questionnaire has been sent to the author, but the author has not saved any progress yet.|
 |In Progress|The author has accessed the questionnaire and saved some amount of work.|
 |Author Submitted|The author has gone through each section of the questionnaire and clicked **Submit answers** at the end.|
-|Accepted|The publisher has marked the questionnaire as **Accepted** using the Status dropdown menu.|
+|Accepted|The publisher has marked the questionnaire as **Accepted** using the Status dropdown menu. This action locks the questionnaire for editing. It also makes the response visible to any libraries [associated](account_management#associating-your-organization-with-libraries) with the publisher.|
+|Not Sent|The publisher has created the questionnaire but not yet sent it to authors.|
+|Library In Progress|A library associated with the publisher has received the accepted questionnaire and begun processing it.|
+|Library Complete|A library associated with the publisher has received the accepted questionnaire and finished processing it.|
+|Not processed|A library associated with the publisher has received the accepted questionnaire, but has not begun processing it yet.|
+
+You can see the history of events that have been performed on each response by clicking **Status History** under **Actions**. Clicking this link will pop up a window that shows:
+
+* The email address of the user who changed the status
+* The updated status
+* The timestamp of the status change
+
+If a response's status has never been changed, the popup window will be blank.
 
 ### Accepting a response
 {:.no_toc}
 
-Once you have determined a response is complete, you can use the Status dropdown menu and mark it as **Accepted**.
+Once you have determined a response is complete, you can use the Status dropdown menu to mark it as **Accepted**. This action locks the questionnaire for editing by authors or staff members. It also makes the questionnaire response visible to any libraries [associated](account_management#associating-your-organization-with-libraries) with your organization.
 
-A popup window will then prompt you to enter an [ISBN](#associating-responses-with-isbns). You can enter an ISBN-10 or ISBN-13 and click **Add**, whereupon OAQ will validate the ISBN. Alternatively, you can click **Skip Add ISBN**, or you can click **Close** to discard your changes and go back.
+Additionally, a popup window will prompt you to enter an [ISBN](#associating-responses-with-isbns). You can enter an ISBN-10 or ISBN-13 and click **Add**, whereupon OAQ will validate the ISBN. Alternatively, you can click **Skip Add ISBN**, or you can click **Close** to discard your changes.
+
+If you need to undo an **Accepted** status, you can change the status as long as two conditions are met:
+
+1. You haven't ended your browser session by leaving the page, refreshing the page, or logging out of OAQ.
+
+2. A library has not changed the status of the response on their end.
+
+Once either of these events has happened, you will not be able to change the **Accepted** status. Contact your OAQ site admin if you have reason to change an **Accepted** status and are unable to.
 
 ### Exporting response data
 {:.no_toc}
 
-The **Answers for questionnaire** page provides you with the option to **Export All Answers**. If you click this button, a CSV file containing all responses in the list will begin downloading.
+The **Responses for questionnaire** page provides you with the option to **Export all responses**. If you click this button, a CSV file containing all responses in the list will begin downloading.
 
-You can also download individual responses by clicking **Download CSV** next to any response.
+You can also download individual responses by clicking the **Download** dropdown next to any response and choosing to download either a **CSV** or **PDF** file.
 
 ### Associating responses with ISBNs
 {:.no_toc}
 
 It's good practice to associate each response with an ISBN if you have it available. Adding an ISBN will allow you to uniquely identify the work in exported data.
 
-1. On the **Answers for questionnaire** page, find the response you want to add an ISBN to.
+1. On the **Responses for questionnaire** page, find the response you want to add an ISBN to.
 2. Under **Actions**, click **Add/Edit ISBN**.
 3. On the page that opens, click **Add another ISBN**.
 4. Enter an ISBN-10 or ISBN-13. OAQ will validate the ISBN before accepting it.

--- a/articles/questions.md
+++ b/articles/questions.md
@@ -10,12 +10,12 @@ For information on managing questions within questionnaires, see "[Editing a que
 
 ## Creating a new question
 
-These steps will create an organization-wide question without adding it to a questionnaire.
+You can create an organization-wide question without adding it to a specific questionnaire:
 
-1. Click **+ Add a question** in the top bar. (Alternatively, you can click **Questions** in the top bar, then click **+ Create new question**.)
+1. Click **+ Add a question** in the top bar. (Alternatively, click **Questions** in the top bar, then click **+ Create new question**.)
 2. On the **New Question** page, fill in the [question components](#question-components).
 3. You can [preview](#previewing-a-question) the question as you go.
-4. When you are finished, click **Create** to save the question, or click **Cancel** to discard your changes and go back.
+4. When you are finished, click **Create** to save the question, or click **Cancel** to discard your changes.
 
 ### Question components
 {:.no_toc}
@@ -23,7 +23,7 @@ These steps will create an organization-wide question without adding it to a que
 |Field|Explanation|
 |--|--|
 |Name|The text of the question that appears in the questionnaire. (For example, `Awards`.)|
-|Help Text|Optional text that appears when an author hovers over the question mark icon next to the question. This text should provide more description or context about what the author should answer. (For example, if the name is `Awards`, useful help text might be, `Are there any awards for which you would like us to nominate your book?`)|
+|Help Text|Optional text that appears when an author hovers over the question mark icon next to the question. This text should provide more description about what the author should answer. (For example, if the name is `Awards`, useful help text might be, `Are there any awards for which you would like us to nominate your book?`)|
 |Type|Controls the accepted format of the answer. (See the [table](#type-field-options) below for more on these options.)|
 |Placeholder|Optional text that appears in gray in the answer field, which authors will overwrite. It's helpful for showing an example answer in a particular format. (Note that placeholder text is not available for all question types.)|
 |Answer Options|This field will only appear when **Dropdown**, **Multiple Choice**, or **Checkboxes** is selected in the [**type** field](#type-field-options). In this field, type each answer that you want to appear in your desired dropdown/multiple choice/checkbox list, and press _Enter_ before typing the next one.|


### PR DESCRIPTION
This PR updates the OAQ publisher workflow documentation based on the following site updates:

* New "Status History" dropdown on Responses page shows a log of actions taken.
* New "Status" options include library actions (Not Sent, Library in Progress, Library Completed, Not Processed).
* Library and publisher associations can now be configured (must be done by OAQ site admin).
* An organization's invitation email message is now customizable.
* Already used questions on the "Add/Remove Questions" page are now dimmed in the dropdown.
* The publisher staff member who sent an invite to an author gets an email notification when the author has submitted a response.
* PDF/CSV downloads now available for individual questionnaire responses.

The diff in this PR is pretty big, so it might be easier to look at the commit for each article:

* Account Management: https://github.com/oaq-docs/publisher-workflow/commit/b1fde3ab557b39d808ee9ec2ff557fad74699a75
* Organizations: https://github.com/oaq-docs/publisher-workflow/commit/0d9033f2d75fb6fa1c21bbc4e0c5c2d00d445d83
* Questionnaires: https://github.com/oaq-docs/publisher-workflow/commit/f3d7d40681829106d580804f4fe914b50194fe02

(I did make some edits to the Questions article as well, but it's mostly copyediting/cleanup stuff.)

/cc @ColinVanAlstine @eslao 