### PR TITLE
[09-08-17] Publisher docs updates

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,7 @@
             » <a class="page-link" href="/publisher-workflow/articles/organizations.html">Organizations</a><br/>
             » <a class="page-link" href="/publisher-workflow/articles/questionnaires.html">Questionnaires</a><br/>
             » <a class="page-link" href="/publisher-workflow/articles/questions.html">Questions</a><br/>
+            » <a class="page-link" href="/publisher-workflow/articles/responses.html">Responses</a><br/>
       </header>
 
       <section>

--- a/articles/account_management.md
+++ b/articles/account_management.md
@@ -15,8 +15,8 @@ The OAQ application supports several types of **account roles**, each with diffe
 | Account role | Permissions |
 |--|--|
 |Site admin| Can see and manage all organizations, including creating organizations and inviting users to an organization. Currently limited to Harvard library staff. |
-|Organization admin | Can [invite staff to the organization](#inviting-others-to-the-organization), [manage organization users](organizations#managing-organization-users), [edit organization details](organizations#editing-organization-details), [create new questionnaires](questionnaires#creating-a-new-questionnaire), [manage questionnaires](questionnaires#actions-you-can-perform-on-a-questionnaire), [send questionnaires to authors](questionnaires#sending-a-questionnaire-to-an-author), and [manage author responses](questionnaires#managing-author-responses). |
-|Organization staff | Can [create new questionnaires](questionnaires#creating-a-new-questionnaire), [manage questionnaires](questionnaires#actions-you-can-perform-on-a-questionnaire), [send questionnaires to authors](questionnaires#sending-a-questionnaire-to-an-author), and [manage author responses](questionnaires#managing-author-responses). |
+|Organization admin | Can [invite staff to the organization](#inviting-others-to-the-organization), [manage organization users](organizations#managing-organization-users), [edit organization details](organizations#editing-organization-details), [create new questionnaires](questionnaires#creating-a-new-questionnaire), [manage questionnaires](questionnaires#actions-you-can-perform-on-a-questionnaire), [send questionnaires to authors](questionnaires#sending-a-questionnaire-to-an-author), and [manage author responses](responses#managing-author-responses). |
+|Organization staff | Can [create new questionnaires](questionnaires#creating-a-new-questionnaire), [manage questionnaires](questionnaires#actions-you-can-perform-on-a-questionnaire), [send questionnaires to authors](questionnaires#sending-a-questionnaire-to-an-author), and [manage author responses](responses#managing-author-responses). |
 |Author | Can view, save, and submit questionnaires. |
 
 ## Getting started as an organization admin
@@ -27,9 +27,9 @@ Your experience as a publisher in OAQ begins when the site admin invites the fir
 
 Each invited organization admin will receive an email that contains an invitation link. If you receive one of these emails and click the link, you will be taken to a page in OAQ where you can confirm your account and create a password. Note that you can always [change your password](account_management#changing-your-password) later.
 
-## Associating your organization with libraries
+## Partnering with libraries
 
-OAQ facilitates the sharing of questionnaire data between publishers and libraries. As a publisher, you can [share author responses](questionnaires#accepting-a-response) with any library of your choosing. Only OAQ [site admins](#types-of-account-roles) can set up publisher–library associations, so talk to the site admin who creates your organization about the libraries you wish to work with.
+OAQ facilitates the sharing of questionnaire data between publishers and libraries. As a publisher, you can [share author responses](responses#accepting-a-response) with any library of your choosing. Only OAQ [site admins](#types-of-account-roles) can set up publisher–library partnerships, so talk to the site admin who creates your organization about the libraries you wish to work with.
 
 ## Inviting others to the organization
 

--- a/articles/organizations.md
+++ b/articles/organizations.md
@@ -6,7 +6,7 @@
 
 An organization in OAQ may be one of two types: publisher or library. This documentation is intended for a publisher workflow.
 
-An organization must have at least one **organization admin** who may create additional **organization staff**. These staff members can [create and manage questionnaires](questionnaires#creating-a-new-questionnaire), [invite authors to respond to them](questionnaires#sending-a-questionnaire-to-an-author), and [manage author responses](questionnaires#managing-responses).
+An organization must have at least one **organization admin** who may create additional **organization staff**. These staff members can [create and manage questionnaires](questionnaires#creating-a-new-questionnaire), [invite authors to respond to them](questionnaires#sending-a-questionnaire-to-an-author), and [manage author responses](responses#managing-responses).
 
 ## Editing organization details
 

--- a/articles/questionnaires.md
+++ b/articles/questionnaires.md
@@ -32,9 +32,9 @@ OAQ allows you to perform a number of actions on a saved questionnaire. When you
 |Edit|Takes you to the [Edit Questionnaire](#editing-a-questionnaire) page.|
 |Send to authors|Pops up a window where you can [invite authors](#sending-a-questionnaire-to-an-author) to the questionnaire.|
 |Clone|Pops up a window where you can enter a name and description in order to [clone](#cloning-a-questionnaire) the questionnaire.|
-|Responses|Takes you to a page where you can [manage author responses](#managing-responses) for the questionnaire.|
+|Responses|Takes you to a page where you can [manage author responses](responses#managing-responses) for the questionnaire.|
 
-The following sections provide more detail on each of these actions.
+The following sections provide more detail on these actions.
 
 ## Viewing a questionnaire
 
@@ -145,7 +145,7 @@ When you are satisfied with your questionnaire, click **I Am Done Making My Ques
 4. In the popup window, enter the author's email address. If you're sending to multiple authors at once, press _Enter_ after typing each address before typing the next one.
 5. Click **Invite** to send the email, or click **Close** to discard your changes.
 
-Clicking **Invite** will send the recipients your [organization's customized email message](organizations#customizing-your-organization-s-questionnaire-invitation-email) with a link to your questionnaire. Additionally, the questionnaire will be added to the [Responses list](#managing-responses) with a [status](#response-status) of _Sent_.
+Clicking **Invite** will send the recipients your [organization's customized email message](organizations#customizing-your-organization-s-questionnaire-invitation-email) with a link to your questionnaire. Additionally, the questionnaire will be added to the [Responses list](responses#managing-responses) with a [status](response#response-statuses) of _Sent_.
 
 The publisher staff member who sends the invite will get an email notification when an author has submitted a response.
 
@@ -160,74 +160,3 @@ To create a questionnaire that is based on an existing questionnaire rather than
 5. Click **Clone** to save your cloned questionnaire, or click **Close** to discard your changes and go back.
 
 Clicking **Clone** will save the new questionnaire to your organization's list. You can then [edit](#editing-a-questionnaire) as desired.
-
-## Managing responses
-
-After you've sent a questionnaire to authors, you can view and manage the status of their responses.
-
-1. Click **Questionnaires** in the top bar to view a list of all your organization's questionnaires.
-2. Find the name of the questionnaire that has the author responses you want to manage.
-3. Under **Actions**, click **Responses**.
-
-The **Responses for questionnaire** page will show a list of each author who has been invited to the questionnaire, along with the date it was last modified and the [status](#response-status) of the response.
-
-Note that each email address in the **Author Email** column is a hyperlink; if you click the link, your default mail program will open with the author's address, a subject line, and a message body already filled in. The message will include the unique URL to the questionnaire. Feel free to modify this email before sending it, or you can use this feature as a way to access the questionnaire URL for later correspondence.
-
-As a publisher, there may be times where you want to work on a questionnaire on behalf of an author. If you click **Start a new response to <name of questionnaire>** at the top of the page, you can begin a questionnaire without generating an email to an author. You can then either submit the questionnaire yourself or share the URL with the author later. You can also work on an author's in-progress questionnaire by clicking **Edit** next to its name in the list.
-
-### Response status
-{:.no_toc}
-
-Here’s an explanation of the **Status** dropdown menu options:
-
-| Status | Meaning |
-|--|--|
-|Sent|The questionnaire has been sent to the author, but the author has not saved any progress yet.|
-|In Progress|The author has accessed the questionnaire and saved some amount of work.|
-|Author Submitted|The author has gone through each section of the questionnaire and clicked **Submit answers** at the end.|
-|Accepted|The publisher has marked the questionnaire as **Accepted** using the Status dropdown menu. This action locks the questionnaire for editing. It also makes the response visible to any libraries [associated](account_management#associating-your-organization-with-libraries) with the publisher.|
-|Not Sent|The publisher has created the questionnaire but not yet sent it to authors.|
-|Library In Progress|A library associated with the publisher has received the accepted questionnaire and begun processing it.|
-|Library Complete|A library associated with the publisher has received the accepted questionnaire and finished processing it.|
-|Not processed|A library associated with the publisher has received the accepted questionnaire, but has not begun processing it yet.|
-
-You can see the history of events that have been performed on each response by clicking **Status History** under **Actions**. Clicking this link will pop up a window that shows:
-
-* The email address of the user who changed the status
-* The updated status
-* The timestamp of the status change
-
-If a response's status has never been changed, the popup window will be blank.
-
-### Accepting a response
-{:.no_toc}
-
-Once you have determined a response is complete, you can use the Status dropdown menu to mark it as **Accepted**. This action locks the questionnaire for editing by authors or staff members. It also makes the questionnaire response visible to any libraries [associated](account_management#associating-your-organization-with-libraries) with your organization.
-
-Additionally, a popup window will prompt you to enter an [ISBN](#associating-responses-with-isbns). You can enter an ISBN-10 or ISBN-13 and click **Add**, whereupon OAQ will validate the ISBN. Alternatively, you can click **Skip Add ISBN**, or you can click **Close** to discard your changes.
-
-If you need to undo an **Accepted** status, you can change the status as long as two conditions are met:
-
-1. You haven't ended your browser session by leaving the page, refreshing the page, or logging out of OAQ.
-
-2. A library has not changed the status of the response on their end.
-
-Once either of these events has happened, you will not be able to change the **Accepted** status. Contact your OAQ site admin if you have reason to change an **Accepted** status and are unable to.
-
-### Exporting response data
-{:.no_toc}
-
-The **Responses for questionnaire** page provides you with the option to **Export all responses**. If you click this button, a CSV file containing all responses in the list will begin downloading.
-
-You can also download individual responses by clicking the **Download** dropdown next to any response and choosing to download either a **CSV** or **PDF** file.
-
-### Associating responses with ISBNs
-{:.no_toc}
-
-It's good practice to associate each response with an ISBN if you have it available. Adding an ISBN will allow you to uniquely identify the work in exported data.
-
-1. On the **Responses for questionnaire** page, find the response you want to add an ISBN to.
-2. Under **Actions**, click **Add/Edit ISBN**.
-3. On the page that opens, click **Add another ISBN**.
-4. Enter an ISBN-10 or ISBN-13. OAQ will validate the ISBN before accepting it.
-5. Click **Save**.

--- a/articles/responses.md
+++ b/articles/responses.md
@@ -1,0 +1,76 @@
+# Reponses
+{:.no_toc}
+
+- TOC
+{:toc}
+
+As a publisher, once you've sent a questionnaire to authors, you can view and manage the status of their responses.
+
+OAQ workflows depend on updated **response statuses** for the communication of data between publishers and libraries. It's important for publishers to keep response statuses current.
+
+## Managing responses
+
+1. Click **Questionnaires** in the top bar to view a list of all your organization's questionnaires.
+2. Find the name of the questionnaire that has the author responses you want to manage.
+3. Under **Actions**, click **Responses**.
+
+The **Responses for questionnaire** page will show a list of each author who has been invited to the questionnaire, along with the date it was last modified and the [status](#response-statuses) of the response.
+
+Note that each email address in the **Author Email** column is a hyperlink; if you click the link, your default mail program will open with the author's address, a subject line, and a message body already filled in. The message will include the unique URL to the questionnaire. Feel free to modify this email before sending it, or you can use this feature as a way to access the questionnaire URL for later correspondence.
+
+As a publisher, there may be times where you want to work on a questionnaire on behalf of an author. If you click **Start a new response to <name of questionnaire>** at the top of the page, you can begin a questionnaire without generating an email to an author. You can then either submit the questionnaire yourself or share the URL with the author later. You can also work on an author's in-progress questionnaire by clicking **Edit** next to its name in the list.
+
+## Response statuses
+
+Here’s an explanation of the **Status** dropdown menu options:
+
+| Status | Meaning |
+|--|--|
+|Sent|The questionnaire has been sent to the author, but the author has not saved any progress yet.|
+|In Progress|The author has accessed the questionnaire and saved some amount of work.|
+|Author Submitted|The author has gone through each section of the questionnaire and clicked **Submit answers** at the end.|
+|Accepted|The publisher has marked the questionnaire as **Accepted** using the Status dropdown menu. This action makes the response visible to any [partner libraries](account_management#partnering-with-libraries).|
+|Not Sent|The publisher has created the questionnaire but not yet sent it to authors.|
+|Library In Progress*|A partner library has received the accepted questionnaire and begun processing it. Note that when a library takes this action, it locks the questionnaire for further editing by publishers and authors.|
+|Library Complete*|A partner library has received the accepted questionnaire and finished processing it.|
+|Not processed*|A partner library has received the accepted questionnaire but has not begun processing it yet.|
+
+*These actions are taken by library users in a separate OAQ environment, not by publishers.
+
+You can see the history of events that have been performed on each response by clicking **Status History** under **Actions**. Clicking this link will pop up a window that shows:
+
+* The email address of the user who changed the status
+* The updated status
+* The timestamp of the status change
+
+If a response's status has never been changed, the popup window will be blank.
+
+## Accepting a response
+
+Once you have determined a response is complete, you can use the Status dropdown menu to mark it as **Accepted**. This action locks the questionnaire for editing by authors or staff members. It also makes the questionnaire response visible to any [partner libraries](account_management#partnering-with-libraries) with your organization.
+
+Additionally, a popup window will prompt you to enter an [ISBN](#associating-responses-with-isbns). You can enter an ISBN-10 or ISBN-13 and click **Add**, whereupon OAQ will validate the ISBN. Alternatively, you can click **Skip Add ISBN**, or you can click **Close** to discard your changes.
+
+If you need to undo an **Accepted** status, you can change the status as long as two conditions are met:
+
+1. You haven't ended your browser session by leaving the page, refreshing the page, or logging out of OAQ.
+
+2. A library has not changed the status of the response on their end.
+
+Once either of these events has happened, you will not be able to change the **Accepted** status. Contact your OAQ site admin if you have reason to change an **Accepted** status and are unable to.
+
+## Exporting response data
+
+The **Responses for questionnaire** page provides you with the option to **Export all responses**. If you click this button, a CSV file containing all responses in the list will begin downloading.
+
+You can also download individual responses by clicking the **Download** dropdown next to any response and choosing to download either a **CSV** or **PDF** file.
+
+## Associating responses with ISBNs
+
+It's good practice to associate each response with an ISBN if you have it available. Adding an ISBN will allow you to uniquely identify the work in exported data.
+
+1. On the **Responses for questionnaire** page, find the response you want to add an ISBN to.
+2. Under **Actions**, click **Add/Edit ISBN**.
+3. On the page that opens, click **Add another ISBN**.
+4. Enter an ISBN-10 or ISBN-13. OAQ will validate the ISBN before accepting it.
+5. Click **Save**.

--- a/articles/responses.md
+++ b/articles/responses.md
@@ -31,7 +31,7 @@ Here’s an explanation of the **Status** dropdown menu options:
 |Author Submitted|The author has gone through each section of the questionnaire and clicked **Submit answers** at the end.|
 |Accepted|The publisher has marked the questionnaire as **Accepted** using the Status dropdown menu. This action makes the response visible to any [partner libraries](account_management#partnering-with-libraries).|
 |Not Sent|The publisher has created the questionnaire but not yet sent it to authors.|
-|Library In Progress*|A partner library has received the accepted questionnaire and begun processing it. Note that when a library takes this action, it locks the questionnaire for further editing by publishers and authors.|
+|Library In Progress*|A partner library has received the accepted questionnaire and begun processing it. Note that when a library takes this action, it locks the questionnaire for further editing by authors or publisher staff members.|
 |Library Complete*|A partner library has received the accepted questionnaire and finished processing it.|
 |Not processed*|A partner library has received the accepted questionnaire but has not begun processing it yet.|
 
@@ -47,7 +47,7 @@ If a response's status has never been changed, the popup window will be blank.
 
 ## Accepting a response
 
-Once you have determined a response is complete, you can use the Status dropdown menu to mark it as **Accepted**. This action locks the questionnaire for editing by authors or staff members. It also makes the questionnaire response visible to any [partner libraries](account_management#partnering-with-libraries) with your organization.
+Once you have determined a response is complete, you can use the Status dropdown menu to mark it as **Accepted**. This action makes the questionnaire response visible to any [partner libraries](account_management#partnering-with-libraries).
 
 Additionally, a popup window will prompt you to enter an [ISBN](#associating-responses-with-isbns). You can enter an ISBN-10 or ISBN-13 and click **Add**, whereupon OAQ will validate the ISBN. Alternatively, you can click **Skip Add ISBN**, or you can click **Close** to discard your changes.
 
@@ -58,6 +58,8 @@ If you need to undo an **Accepted** status, you can change the status as long as
 2. A library has not changed the status of the response on their end.
 
 Once either of these events has happened, you will not be able to change the **Accepted** status. Contact your OAQ site admin if you have reason to change an **Accepted** status and are unable to.
+
+When a library begins processing the response in their separate OAQ environment, a library user will change the status to **Library In Progress**. This action locks the questionnaire for editing by authors or publisher staff members.
 
 ## Exporting response data
 


### PR DESCRIPTION
This PR addresses the following feedback from @eslao (sent via email):

> I'm also wondering whether the word "association" in the documentation (and in the application) is slightly confusing, since we're using it to describe both the association of responses to questionnaires and the association of library organizations with publisher organizations. Perhaps we could consider more distinct language about questionnaire/response "association" and library/publisher "partnerships".

As in the [library docs updates](https://github.com/oaq-docs/library-workflow/pull/3), I changed "associating" to "partnering" throughout. I left the term "association" when it applied to the questionnaire/response relationship.

> I'm also wondering whether, in the publisher-facing documentation, "Managing Responses" could be its own section, as it's a very separate phase of the publisher workflow and may involve staff who aren't involved in questionnaire creation (or even necessarily invitations).

This makes sense to me. I created a new article called "Responses" and moved the relevant content out of "Questionnaires" into it.

> The way it’s supposed to work is: A publisher changing the response status to “Accepted” makes the response visible to libraries. Libraries can then change the status to “Library In Progress” to lock the response.

* I added a note to the table in "Response statuses." 
* I added asterisks to the last few entries in the table to denote actions that are performed by library users.
* I clarified the **Accepted** vs **Library In Progress** statuses under "Accepting a response."

Note this PR also includes some general editing/cleanup.

/cc @eslao @ColinVanAlstine 